### PR TITLE
useEffect for results --> tab switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,7 +399,6 @@ const App: React.FC = () => {
       const jsonResponse: Results = await response.json()
       if (Object.keys(jsonResponse).length !== 0) {
         setResults(jsonResponse)
-	setCurrentPage((!!jsonResponse?.ballotsCounted) ? 'results' : 'info')
       }
     } else {
       console.log(response.status, response.statusText);
@@ -437,6 +436,11 @@ const App: React.FC = () => {
     }, refreshInterval * 1000);
     return () => clearTimeout(timer)
   })
+
+  // new results, go to results tab
+  useEffect(() => {
+    setCurrentPage((!!results?.ballotsCounted) ? 'results' : 'info')
+  }, [results])
 
   const PoweredBy = () => (
     <Container>


### PR DESCRIPTION
My read is that `useState` is not going to change the initial value of a variable on second re-render, so we have to update the current tab based on a change in `results`, so using `useEffect`.

We should probably only move to the tab when *new* results appear, not every minute, but leaving that for an additional commit here.